### PR TITLE
specialOne/Two/Three alias for f/g/h

### DIFF
--- a/scripts/keybinds.lua
+++ b/scripts/keybinds.lua
@@ -29,6 +29,9 @@ keybinds.availableInputs = {
   f = true,
   g = true,
   h = true,
+  specialOne = true,
+  specialTwo = true,
+  specialThree = true,
   -- Don't set this one to false!
   aimOffset = true
 }
@@ -53,6 +56,9 @@ keybinds.inputStrings = {
   f = "f",
   g = "g",
   h = "h",
+  specialone = "specialOne",
+  specialtwo = "specialTwo",
+  specialthree = "specialThree",
   -- Don't set this one to false!
   aimoffset = "aimOffset"
 }
@@ -64,7 +70,7 @@ keybinds.input = {
   onGround = true, running = false, walking = false, jumping = false,
   facingDirection = 1, liquidPercentage = 0,
   position = {0, 0}, aimPosition = {0, 0}, aimOffset = {2, 2}, aimRelative = {0, 0},
-  f = false, g = false, h = false
+  f = false, g = false, h = false, specialOne = false, specialTwo = false, specialThree = false
 }
 
 --[[ Finalizes Keybinds by injecting function keybinds.update in the tech's main update function.]]
@@ -162,8 +168,11 @@ function keybinds.updateInput(args)
   sb.setLogMap("player_rel", string.format("%s %s", input.aimRelative[1], input.aimRelative[2]))
 
   input.f = args.moves.special == 1
+  input.specialOne = input.f
   input.g = args.moves.special == 2
+  input.specialTwo = input.g
   input.h = args.moves.special == 3
+  input.specialThree = input.h
 end
 
 --[[ Returns a keybind table from the given string.


### PR DESCRIPTION
Input options `specialOne`, `specialTwo` and `specialThree` added.
* These values reflect the values for the input options `f`, `g` and `h` respectively.

This increases clarity for the end user, since users may not have their controls for the special actions set to <kbd>F</kbd>, <kbd>G</kbd> and <kbd>H</kbd>.  
The old input options are still present, to keep the mod compatible with older implementations. Even though they are still present, it is discouraged to use `f`, `g` and/or `h`.

Example:  
User has `PlayerTechAction2` bound to <kbd>V</kbd> rather than <kbd>G</kbd>.  
The keybind would still read `g`, so the user expects they must press <kbd>G</kbd> to call the function, instead of the correct <kbd>V</kbd>.