### PR TITLE
Keywords 'only' and 'all'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,171 +2,52 @@
 
 Easily bind functions to one or more input methods.
 
-**Note: Parts of this README may be moved to [the Wiki](https://github.com/Silverfeelin/Starbound-Keybinds/wiki) in the future to keep everything neat and tidy.**
-
-## Table of Contents
-
-- [Installation](#installation)
-- [Usage](#usage)
-- [Syntax Options](#syntax-options)
-- [Value Types](#value-types)
-- [Bind Object](#bind-object)
-- [Contributing](#contributing)
-
-## Installation
-
-> It is recommended to put the script in a folder dedicated to your mod. This can help prevent version conflicts with other mods.  
-> Example: `/Starbound/mods/MyMod/scripts/myMod/keybinds.lua`
-
-The keybinds script may be included in your own mod. This way, users don't have to manually install the library.
-
-* Place the script somewhere in your mod folder.
-
-[Back to Top](#starbound-keybinds)
-
-## Usage
-
-* At the top of your script, require the `keybinds.lua` script.
-  * Example: `require "/scripts/myMod/keybinds.lua"`
-
-To create a keybind, use the below function anywhere in your script. You'll most likely want to do this in the `init` function.  
-
-> Bind.create([syntax](#syntax), [func](#function), [[repeatable]](#repeatable), [[disabled]](#disabled))
-
-#### Syntax
-Default syntax for one option: `key=value`.
-
-* Options are separated by a space.  
-  `"specialOne down"`
-* Keys and values are separated by `=`.  
-  `"specialOne=true down=true up=false"`
-* The value is optional. Values default to `true`.  
-  `"specialOne"` = `"specialOne=true"`
-* Keys are case-insensitive.  
-  `"Specialone"`
-
-[View all supported options.](#syntax-1)
-
-#### Function
-
-When all options match, this function will fire. The first argument to this function is the [bind object](#Bind-Object).
-
-``` lua
-function myFunction() sb.logInfo("You pressed the F key!") end
-Bind.create("specialOne", myFunction)
-Bind.create("specialTwo", function() sb.logInfo("You pressed the G key!") end)
-Bind.create("up down", function(bind)
-  sb.logInfo("You pressed up and down for the first time!")
-  bind:unbind()
-end)
-```
-
-#### Repeatable `optional`
-This value indicates whether the keybind should activate only once (`false`), or every game tick as long as the current game input matches the arguments of the keybind (`true`). Defaults to `false`.
-
-#### Disabled `optional`
-If `true`, the created bind can not activate until `bind:rebind()` is called.
-
-#### Return value
-Reference to the bind, which can be used to manipulate the bind.
-See [Bind Object](#bind-object).
+Write:
 
 ```lua
-local bind = Bind.create("specialOne", myFunction)
+require "/scripts/keybinds.lua"
+
+function init()
+  Bind.create("up down specialOne", toggleNoclip)
+  Bind.create("up=false down=false specialOne", toggleSit)
+end
 ```
 
-[Back to Top](#starbound-keybinds)
+Instead of:
 
-## Syntax
-
-The descriptions are based on the default keyboard configuration of the game.
-
-| Key | Type | Description |
-| --- | ---- | ----------- |
-| `up` | [boolean](#boolean) | True while holding <kbd>w</kbd>. |
-| `left` | [boolean](#boolean) | True while holding <kbd>a</kbd>. |
-| `down` | [boolean](#boolean) | True while holding <kbd>s</kbd>. |
-| `right` | [boolean](#boolean) | True while holding <kbd>d</kbd>. |
-| `primaryFire` | [boolean](#boolean) | True while holding down the left mouse button. |
-| `altFire` | [boolean](#boolean) | True while holding down the right mouse button. |
-| `shift` | [boolean](#boolean) | True while holding down <kbd>shift</kbd>. |
-| `onGround` | [boolean](#boolean) | True while standing on the ground. |
-| `running` | [boolean](#boolean) | True while actively running. |
-| `walking` | [boolean](#boolean) | True while actively walking (running while holding <kbd>shift</kbd>). |
-| `jumping` | [boolean](#boolean) | True while holding <kbd>space</kbd>. |
-| `facingDirection` | [float](#float) | `-1` while facing left. `1` while facing right. |
-| `liquidPercentage` | [float](#float) | Value between `0` and `1`, indicating what percentage of your hitbox is submerged. |
-| `position` | [vec2](#vec2) | World position of your character in blocks. |
-| `aimPosition` | [vec2](#vec2) | Position of your cursor on the world, in blocks.
-| `aimRelative` | [vec2](#vec2) | `aimPosition` relative to `position`. |
-| `specialOne` | [boolean](#boolean) | True while holding the first tech action key (`PlayerTechAction1`). |
-| `specialTwo` | [boolean](#boolean) | True while holding the second tech action key (`PlayerTechAction2`). |
-| `specialThree` | [boolean](#boolean) | True while holding the third tech action key (`PlayerTechAction3`). |
-
-### Options
-
-These keywords have a special meaning. They should be combined with other options.
-
-| Key | Type | Description |
-| --- | ---- | ----------- |
-| `all` | [boolean](#boolean) | If set, the bind can only reactivate when all input options no longer match.<br>An example: `"all up down"` will only fire when `up` and `down` have both been pressed like usual. The bind can only fire again if both `up` and `down` have been released. Normally, the bind can fire again even if only one key has been released. |
-| `only` | [boolean](#boolean) | With this value set, all omitted **key** options will be set to false. Options such as `onGround`, `running` or `facingDirection` are unaffected, as these options can not be pressed or released.<br>An example: `"only primaryFire up"` will be interpreted as `primaryFire=true up=true altFire=false left=false` et cetera.|
-| `aimOffset` | [vec2](#vec2) | Value indicating how far `position`, `aimPosition` and `aimRelative` may be off. Defaults to `2,2`.<br>An example:  `"aimRelative=20,25 aimOffset=2,10"`. Valid: `aimRelative` between `(18,15)` and `(22,35)`. |
-| `time` | [float](#float) | Value indicating how long the other input options should match before running the function.<br>With `repeatable` set, the bind function will still fire every update as long as the bind is active. |
-
-[Back to Top](#starbound-keybinds)
-
-## Value Types
-
-#### Boolean
-`true` or `false`. `true` may be omitted as it is the default value.
 ```lua
-Bind.create("down=true up=false specialOne", myFunction)
+local firedNoclip, firedSit = false, false
+
+function update(args)
+  if args.moves.up and args.moves.down and args.moves.special1 then
+    if not firedNoclip then
+      firedNoclip = true
+      toggleNoclip()
+    end
+  else
+    firedNoclip = false
+  end
+
+  if not args.moves.up and not args.moves.down and args.moves.special1 then
+    if not firedSit then
+      firedSit = true
+      toggleSit()
+    end
+  else
+    firedSit = false
+  end
+end
 ```
 
+## Wiki
 
-#### Float
+You should be able to find the information you need on [the wiki](https://github.com/Silverfeelin/Starbound-Keybinds/wiki).
 
-Any positive or negative number. Decimals are allowed, but may not work in certain input options.
-```lua
-Bind.create("facingDirection=1", myFunction)
-```
-
-#### Vec2
-Two [floats](#float), separated with a comma.
-```lua
-Bind.create("position=100,200 aimOffset=10,10", myFunction)
-```
-
-[Back to Top](#starbound-keybinds)
-
-## Bind Object
-
-The `Bind.create` function returns a bind object, that you can manipulate with the functions described below.
-```lua
--- Create a bind
-local bind = Bind.create(args, f, repeatable)
-
--- Set new input options.
-bind:change(newArgs, f, repeatable)
-
--- Set repeatable to true. Nil values are ignored; the old values will be kept.
-bind:change(nil, nil, true)
-
--- Swap the functions of both binds. Input options and repeatable remain untouched.
-bind:swap(otherBind)
-
--- Unbind. The bind can no longer activate.
-bind:unbind()
-
--- Rebind. The bind can activate again.
-bind:rebind()
-
--- Checks if the bind can activate.
-local active = bind:isActive()
-```
-
-[Back to Top](#starbound-keybinds)
+* [Installation](https://github.com/Silverfeelin/Starbound-Keybinds/wiki/Installation)
+* [Usage](https://github.com/Silverfeelin/Starbound-Keybinds/wiki/Usage)
+* [Options](https://github.com/Silverfeelin/Starbound-Keybinds/wiki/Options)
+    * [Value Types](https://github.com/Silverfeelin/Starbound-Keybinds/wiki/Value-Types)
+* [Bind Object](https://github.com/Silverfeelin/Starbound-Keybinds/wiki/Bind-Object)
 
 ## Contributing
 If you have any suggestions or feedback that might help improve this library, please create an issue on the [Issues page](https://github.com/Silverfeelin/Starbound-Keybinds/issues).

--- a/README.md
+++ b/README.md
@@ -4,35 +4,46 @@ Easily bind functions to one or more input methods.
 **Note: Parts of this README may be moved to [the Wiki](https://github.com/Silverfeelin/Starbound-Keybinds/wiki) in the future to keep everything neat and tidy.**
 
 ## Table of Contents
+
 - [Installation](#installation)
 - [Usage](#usage)
 - [Syntax Options](#syntax-options)
 - [Value Types](#value-types)
 - [Bind Object](#bind-object)
-- [Planned](#planned)
 - [Potential Issues](#potential-issues)
 - [Contributing](#contributing)
 
 ## Installation
 
+#### Stand-alone script
+
+The keybinds script may be included in your own mod. This way, users don't have to install the Keybinds library themselves to use your mod. If you do this, please do not remove the link to this repository from the file.
+
+* Place the script somewhere in your mod folder. The place you put the script in will affect the require path (see [Usage](#usage)).
+
 #### Mod pack
+
 This file ensures that, as long it is present in your mods folder, the library will be loaded and will be available in other scripts. It allows this mod to be used as a dependency in other mods, if these other mods don't include a copy of the script.
 * Place the `Keybinds.pak` file in your mods folder (eg. `D:\Steam\steamapps\common\Starbound\mods\`).
 
-#### Stand-alone script
-This script can be included in your own mod. This way, users don't have to install the Keybinds library themselves to use your mod.
-* Place the script in `/<yourMod>/scripts/`. The file name should remain `keybinds.lua`.
+#### Preventing Conflicts
 
-Note that bundled versions may conflict. IE. an outdated version in one mod may be used instead of the updated version in another mod, due to the load order of mods. As of v1.2.2, Keybinds will log a message indicating what version of the mod is loaded.
+Note that users may run into issues when bundling the mod pack with your mod. For example, an outdated version in another mod may be used instead of the newer  version in your mod.  
+As of [v1.2.2](https://github.com/Silverfeelin/Starbound-WEdit/releases/tag/v1.2.2.1), Keybinds will log a message indicating what version of the mod is loaded.
+
+To prevent conflicts, it is recommended to include the keybinds script in your own mod, and to use a different location for the script. For example, place the script in `/MyMod/scripts/MyMod/keybinds.lua`. This way you'll always know which version will be loaded in your tech mod.
 
 [Back to Top](#starbound-keybinds)
 
 ## Usage
 Before you can create keybinds in your script, you'll first have to load the library.
-* At the top of your script, add `require "/scripts/keybinds.lua"`.  
+* At the top of your script, add `require "/scripts/keybinds.lua"`.
+  * If you changed the location of the script, please update the require path accordingly.
 
-To create a keybind, use the below function anywhere in your script. When a keybind is created, it will automatically activate.  
-You can press on any of the function parameters for more information.
+To create a keybind, use the below function anywhere in your script. Binds should be created after the update function is defined, so it is recommended to create binds in the `init` function.  
+When a keybind is created, it will automatically be ready for use.  
+
+You can press on any of the below function parameters for more information on how to create binds.
 
 > Bind.create([syntax](#syntax), [func](#function), [repeatable](#repeatable))
 
@@ -40,18 +51,17 @@ You can press on any of the function parameters for more information.
 Default syntax for one key: `key=value`. Please note the following:
 
 1. Every input key and value pair should be separated with a space.  
-  `"f down"`
+  `"specialOne down"`
 2. Key and value in a pair should be separated with `=`.  
-  `"f=true down=true up=false"`
-3. The value is optional. By default, `true` will be set if no value is specified.
-⋅⋅* Note that keys which don't accept a boolean will not work without a value.  
-  `"f down up=false"`
+  `"specialOne=true down=true up=false"`
+3. The value is optional. By default, `true` will be set if no value is specified. Note that keys which don't accept a boolean value will not work without a value.  
+  `"specialOne down up=false"`
 4. Keys are case-insensitive.  
-  `"facingDirection=1"` equals `"facingdirection=1"`.
+  `"facingDirection=1"` = `"facingdirection=1"`.
 
-You can also pass a table instead of a formatted string. Every parameter must include a value here, though.  
+You can also pass a table instead of a formatted string. Every key in the table must have a value here, though.  
 ``` lua
-{f = true, right = true, up = false}
+{specialOne = true, right = true, up = false}
 {aimOffset = {10, 10}, aimRelative = {25,20} }
 ```
 
@@ -60,13 +70,13 @@ When the current game input matches the arguments of a created and active keybin
 Keep in mind that function parameters are not supported.
 ``` lua
 function myFunction() sb.logInfo("You pressed the F key!") end
-Bind.create("f", myFunction)
-Bind.create("g", function() sb.logInfo("You pressed the G key!") end)
+Bind.create("specialOne", myFunction)
+Bind.create("specialTwo", function() sb.logInfo("You pressed the G key!") end)
 ```
 
 #### Repeatable
 This value indicates whether the keybind should activate only once (false), or every game tick as long as the current game input matches the arguments of the keybind (true). Defaults to false.  
-Note that a keybind will reset once one or more input options of it no longer match the current game input. This means the keybind `Bind.create("f", func, false)` will trigger once every time the `f` key is pressed down.
+Note that a keybind will reset once one or more input options of it no longer match the current game input. This means the keybind `Bind.create("specialOne", func, false)` will trigger once every time the `specialOne` key is pressed down.
 
 [Back to Top](#starbound-keybinds)
 
@@ -95,7 +105,8 @@ For every input option, please refer to the documentation of it's value type. Th
 | `specialTwo` | [boolean](#boolean) | True while holding the second tech action key (`PlayerTechAction2`). |
 | `specialThree` | [boolean](#boolean) | True while holding the third tech action key (`PlayerTechAction3`). |
 | aimOffset | [vec2](#vec2) | Value indicating how far `position`, `aimPosition` and `aimRelative` may be off. With no value set, the default value `2,2` is used.<br>An example:  `"aimRelative=20,25 aimOffset=2,10"`<br>If your relative aim is `(21, 17)`, the result would be true. |
-| time | [float](#float) | Value indicating how long the other input options should match before running the function. Note that this time is **not** used as an interval when repeatable is set to true; the function will still be called every tick. |
+| time | [float](#float) | Value indicating how long the other input options should match before running the function.<br>Note that this time is **not** used as an interval when repeatable is set to true; the function will still be called every tick. |
+| only | [boolean](#boolean) | With this value set, all omitted key options (i.e. `primaryFire` or `w`) will be set to false. Options such as `onGround`, `running` or `facingDirection` are uanffected, as these options can not be "pressed".<br>An example: `only primaryFire up` will be interpreted as `primaryFire=true up=true altFire=false left=false` et cetera.|
 
 [Back to Top](#starbound-keybinds)
 
@@ -104,7 +115,13 @@ For every input option, please refer to the documentation of it's value type. Th
 #### Boolean
 `true` or `false`
 ```lua
-Bind.create("f=true, up=false", myFunction)
+Bind.create("specialOne=true up=false", myFunction)
+```
+
+`true` may be omitted; it is the default value when an option is present.
+
+```lua
+Bind.create("specialOne up=false", myFunction)
 ```
 
 #### Float
@@ -140,13 +157,9 @@ bind:rebind()
 
 [Back to Top](#starbound-keybinds)
 
-## Planned
-Nothing yet. Feel free to suggest things on [the discussion page](http://community.playstarbound.com/threads/library-tech-keybinds.112606/)!
-
-[Back to Top](#starbound-keybinds)
-
 ## Potential Issues
-* Multiple tech scripts could bind the same keys. This is actually a double-edged sword, since there may be scenarios where you'd want multiple different actions bound to the same key.
+* Multiple tech scripts could bind the same keys and act upon them.  
+This is actually a double-edged sword, since there may be scenarios where you'd want multiple actions bound to the same key.
 
 [Back to Top](#starbound-keybinds)
 

--- a/README.md
+++ b/README.md
@@ -10,78 +10,75 @@ Easily bind functions to one or more input methods.
 - [Syntax Options](#syntax-options)
 - [Value Types](#value-types)
 - [Bind Object](#bind-object)
-- [Potential Issues](#potential-issues)
 - [Contributing](#contributing)
 
 ## Installation
 
-#### Stand-alone script
+> It is recommended to put the script in a folder dedicated to your mod. This can help prevent version conflicts with other mods.  
+> Example: `/Starbound/mods/MyMod/scripts/myMod/keybinds.lua`
 
-The keybinds script may be included in your own mod. This way, users don't have to install the Keybinds library themselves to use your mod. If you do this, please do not remove the link to this repository from the file.
+The keybinds script may be included in your own mod. This way, users don't have to manually install the library.
 
-* Place the script somewhere in your mod folder. The place you put the script in will affect the require path (see [Usage](#usage)).
-
-#### Mod pack
-
-This file ensures that, as long it is present in your mods folder, the library will be loaded and will be available in other scripts. It allows this mod to be used as a dependency in other mods, if these other mods don't include a copy of the script.
-* Place the `Keybinds.pak` file in your mods folder (eg. `D:\Steam\steamapps\common\Starbound\mods\`).
-
-#### Preventing Conflicts
-
-Note that users may run into issues when bundling the mod pack with your mod. For example, an outdated version in another mod may be used instead of the newer  version in your mod.  
-As of [v1.2.2](https://github.com/Silverfeelin/Starbound-WEdit/releases/tag/v1.2.2.1), Keybinds will log a message indicating what version of the mod is loaded.
-
-To prevent conflicts, it is recommended to include the keybinds script in your own mod, and to use a different location for the script. For example, place the script in `/MyMod/scripts/MyMod/keybinds.lua`. This way you'll always know which version will be loaded in your tech mod.
+* Place the script somewhere in your mod folder.
 
 [Back to Top](#starbound-keybinds)
 
 ## Usage
-Before you can create keybinds in your script, you'll first have to load the library.
-* At the top of your script, add `require "/scripts/keybinds.lua"`.
-  * If you changed the location of the script, please update the require path accordingly.
 
-To create a keybind, use the below function anywhere in your script. Binds should be created after the update function is defined, so it is recommended to create binds in the `init` function.  
-When a keybind is created, it will automatically be ready for use.  
+* At the top of your script, require the `keybinds.lua` script.
+  * Example: `require "/scripts/myMod/keybinds.lua"`
 
-You can press on any of the below function parameters for more information on how to create binds.
+To create a keybind, use the below function anywhere in your script. You'll most likely want to do this in the `init` function.  
 
-> Bind.create([syntax](#syntax), [func](#function), [repeatable](#repeatable))
+> Bind.create([syntax](#syntax), [func](#function), [[repeatable]](#repeatable), [[disabled]](#disabled))
 
 #### Syntax
-Default syntax for one key: `key=value`. Please note the following:
+Default syntax for one option: `key=value`.
 
-1. Every input key and value pair should be separated with a space.  
+* Options are separated by a space.  
   `"specialOne down"`
-2. Key and value in a pair should be separated with `=`.  
+* Keys and values are separated by `=`.  
   `"specialOne=true down=true up=false"`
-3. The value is optional. By default, `true` will be set if no value is specified. Note that keys which don't accept a boolean value will not work without a value.  
-  `"specialOne down up=false"`
-4. Keys are case-insensitive.  
-  `"facingDirection=1"` = `"facingdirection=1"`.
+* The value is optional. Values default to `true`.  
+  `"specialOne"` = `"specialOne=true"`
+* Keys are case-insensitive.  
+  `"Specialone"`
 
-You can also pass a table instead of a formatted string. Every key in the table must have a value here, though.  
-``` lua
-{specialOne = true, right = true, up = false}
-{aimOffset = {10, 10}, aimRelative = {25,20} }
-```
+[View all supported options.](#syntax-1)
 
 #### Function
-When the current game input matches the arguments of a created and active keybind, the function will be called. You can either pass a function that's already defined, or declare an anonymous function.  
-Keep in mind that function parameters are not supported.
+
+When all options match, this function will fire. The first argument to this function is the [bind object](#Bind-Object).
+
 ``` lua
 function myFunction() sb.logInfo("You pressed the F key!") end
 Bind.create("specialOne", myFunction)
 Bind.create("specialTwo", function() sb.logInfo("You pressed the G key!") end)
+Bind.create("up down", function(bind)
+  sb.logInfo("You pressed up and down for the first time!")
+  bind:unbind()
+end)
 ```
 
-#### Repeatable
-This value indicates whether the keybind should activate only once (false), or every game tick as long as the current game input matches the arguments of the keybind (true). Defaults to false.  
-Note that a keybind will reset once one or more input options of it no longer match the current game input. This means the keybind `Bind.create("specialOne", func, false)` will trigger once every time the `specialOne` key is pressed down.
+#### Repeatable `optional`
+This value indicates whether the keybind should activate only once (`false`), or every game tick as long as the current game input matches the arguments of the keybind (`true`). Defaults to `false`.
+
+#### Disabled `optional `
+If `true`, the created bind can not activate until `bind:rebind()` is called.
+
+#### Return value
+Reference to the bind, which can be used to manipulate the bind.
+See [Bind Object](#bind-object).
+
+```lua
+local bind = Bind.create("specialOne", myFunction)
+```
 
 [Back to Top](#starbound-keybinds)
 
-## Syntax Options
-For every input option, please refer to the documentation of it's value type. The descriptions are based on the default keyboard configuration of the game.
+## Syntax
+
+The descriptions are based on the default keyboard configuration of the game.
 
 | Key | Type | Description |
 | --- | ---- | ----------- |
@@ -94,8 +91,8 @@ For every input option, please refer to the documentation of it's value type. Th
 | `shift` | [boolean](#boolean) | True while holding down <kbd>shift</kbd>. |
 | `onGround` | [boolean](#boolean) | True while standing on the ground. |
 | `running` | [boolean](#boolean) | True while actively running. |
-| `walking` | [boolean](#boolean) | True while actively walking (running while holding shift). |
-| `jumping` | [boolean](#boolean) | True while holding space. |
+| `walking` | [boolean](#boolean) | True while actively walking (running while holding <kbd>shift</kbd>). |
+| `jumping` | [boolean](#boolean) | True while holding <kbd>space</kbd>. |
 | `facingDirection` | [float](#float) | `-1` while facing left. `1` while facing right. |
 | `liquidPercentage` | [float](#float) | Value between `0` and `1`, indicating what percentage of your hitbox is submerged. |
 | `position` | [vec2](#vec2) | World position of your character in blocks. |
@@ -104,25 +101,28 @@ For every input option, please refer to the documentation of it's value type. Th
 | `specialOne` | [boolean](#boolean) | True while holding the first tech action key (`PlayerTechAction1`). |
 | `specialTwo` | [boolean](#boolean) | True while holding the second tech action key (`PlayerTechAction2`). |
 | `specialThree` | [boolean](#boolean) | True while holding the third tech action key (`PlayerTechAction3`). |
-| aimOffset | [vec2](#vec2) | Value indicating how far `position`, `aimPosition` and `aimRelative` may be off. With no value set, the default value `2,2` is used.<br>An example:  `"aimRelative=20,25 aimOffset=2,10"`<br>If your relative aim is `(21, 17)`, the result would be true. |
-| time | [float](#float) | Value indicating how long the other input options should match before running the function.<br>Note that this time is **not** used as an interval when repeatable is set to true; the function will still be called every tick. |
-| only | [boolean](#boolean) | With this value set, all omitted key options (i.e. `primaryFire` or `w`) will be set to false. Options such as `onGround`, `running` or `facingDirection` are uanffected, as these options can not be "pressed".<br>An example: `only primaryFire up` will be interpreted as `primaryFire=true up=true altFire=false left=false` et cetera.|
+
+### Options
+
+These keywords have a special meaning. They should be combined with other options.
+
+| Key | Type | Description |
+| --- | ---- | ----------- |
+| `all` | [boolean](#boolean) | If set, the bind can only reactivate when all input options no longer match.<br>An example: `"all up down"` will only fire when `up` and `down` have both been pressed like usual. The bind can only fire again if both `up` and `down` have been released. Normally, the bind can fire again even if only one key has been released. |
+| `only` | [boolean](#boolean) | With this value set, all omitted **key** options will be set to false. Options such as `onGround`, `running` or `facingDirection` are unaffected, as these options can not be pressed or released.<br>An example: `"only primaryFire up"` will be interpreted as `primaryFire=true up=true altFire=false left=false` et cetera.|
+| `aimOffset` | [vec2](#vec2) | Value indicating how far `position`, `aimPosition` and `aimRelative` may be off. Defaults to `2,2`.<br>An example:  `"aimRelative=20,25 aimOffset=2,10"`. Valid: `aimRelative` between `(18,15)` and `(22,35)`. |
+| `time` | [float](#float) | Value indicating how long the other input options should match before running the function.<br>With `repeatable` set, the bind function will still fire every update as long as the bind is active. |
 
 [Back to Top](#starbound-keybinds)
 
 ## Value Types
 
 #### Boolean
-`true` or `false`
+`true` or `false`. `true` may be omitted as it is the default value.
 ```lua
-Bind.create("specialOne=true up=false", myFunction)
+Bind.create("down=true up=false specialOne", myFunction)
 ```
 
-`true` may be omitted; it is the default value when an option is present.
-
-```lua
-Bind.create("specialOne up=false", myFunction)
-```
 
 #### Float
 Any positive or negative number. Decimals are allowed, but may not work in certain input options.
@@ -131,7 +131,7 @@ Bind.create("facingDirection=1", myFunction)
 ```
 
 #### Vec2
-Two floats, separated with a comma.
+Two [floats](#float), separated with a comma.
 ```lua
 Bind.create("position=100,200 aimOffset=10,10", myFunction)
 ```
@@ -143,28 +143,30 @@ The `Bind.create` function returns a bind object, that you can manipulate with t
 ```lua
 -- Create a bind
 local bind = Bind.create(args, f, repeatable)
+
 -- Set new input options.
 bind:change(newArgs, f, repeatable)
+
 -- Set repeatable to true. Nil values are ignored; the old values will be kept.
 bind:change(nil, nil, true)
+
 -- Swap the functions of both binds. Input options and repeatable remain untouched.
 bind:swap(otherBind)
--- Unbind; make the binding inactive. Doesn't alter bindings that are already inactive.
+
+-- Unbind. The bind can no longer activate.
 bind:unbind()
--- Rebind; make the binding active. Doesn't alter bindings that are already active.
+
+-- Rebind. The bind can activate again.
 bind:rebind()
+
+-- Checks if the bind can activate.
+local active = bind:isActive()
 ```
 
 [Back to Top](#starbound-keybinds)
 
-## Potential Issues
-* Multiple tech scripts could bind the same keys and act upon them.  
-This is actually a double-edged sword, since there may be scenarios where you'd want multiple actions bound to the same key.
-
-[Back to Top](#starbound-keybinds)
-
 ## Contributing
-If you have any suggestions or feedback that might help improve this mod, please do post them [the discussion page](http://community.playstarbound.com/threads/library-tech-keybinds.112606/).  
-You can also create pull requests and contribute directly to the mod!
+If you have any suggestions or feedback that might help improve this library, please create an issue on the [Issues page](https://github.com/Silverfeelin/Starbound-Keybinds/issues).
+You can also create pull requests and contribute directly!
 
 [Back to Top](#starbound-keybinds)

--- a/scripts/keybinds.lua
+++ b/scripts/keybinds.lua
@@ -6,7 +6,7 @@ https://github.com/Silverfeelin/Starbound-Keybinds
 keybinds = {
   binds = {},
   initialized = false,
-  version = "1.3.2"
+  version = "1.3.3"
 }
 
 -- For every type of input, set whether it can be bound.
@@ -35,8 +35,9 @@ keybinds.availableInputs = {
   specialTwo = true,
   specialThree = true,
   time = true,
-  -- Don't set this one to false, ever!
-  aimOffset = true
+  -- Don't set these to false, ever!
+  aimOffset = true,
+  only = true
 }
 
 -- Set used to allow case-insensitive input strings.
@@ -57,14 +58,32 @@ keybinds.inputStrings = {
   position = "position",
   aimposition = "aimPosition",
   aimrelative = "aimRelative",
-  f = "f",
-  g = "g",
-  h = "h",
+  f = "specialOne",
+  g = "specialTwo",
+  h = "specialThree",
   specialone = "specialOne",
   specialtwo = "specialTwo",
   specialthree = "specialThree",
   time = "time",
-  aimoffset = "aimOffset"
+  aimoffset = "aimOffset",
+  only = "only"
+}
+
+-- Options that are specifically bound to keys users can hold down.
+keybinds.keys = {
+  up = true,
+  left = true,
+  down = true,
+  right = true,
+  primaryFire = true,
+  altFire = true,
+  shift = true,
+  f = true,
+  g = true,
+  h = true,
+  specialOne = true,
+  specialTwo = true,
+  specialThree = true
 }
 
 -- Default values, do not touch.
@@ -75,7 +94,7 @@ keybinds.input = {
   facingDirection = 1, liquidPercentage = 0,
   position = {0, 0}, aimPosition = {0, 0}, aimOffset = {2, 2}, aimRelative = {0, 0},
   f = false, g = false, h = false, specialOne = false, specialTwo = false, specialThree = false,
-  time = 0
+  time = 0, only = false
 }
 
 -- Unique Bind identifier, used to track time without worrying about shifting indices.
@@ -156,11 +175,8 @@ function keybinds.updateInput(args)
   }
   sb.setLogMap("player_rel", string.format("%s %s", input.aimRelative[1], input.aimRelative[2]))
 
-  input.f = args.moves.special1
   input.specialOne = input.f
-  input.g = args.moves.special2
   input.specialTwo = input.g
-  input.h = args.moves.special3
   input.specialThree = input.h
 end
 
@@ -253,6 +269,15 @@ function Bind:change(args, f, repeatable)
     elseif type(v) == "table" and #v == 2 and type(v[1]) == "number" and type(v[2]) == "number" then
       -- Convert point table tostring to vec2
       keybinds.setVec2(v)
+    end
+  end
+
+  -- If "only" is set, set valid unset keys to false.
+  if self.args["only"] then
+    for k,v in pairs(keybinds.availableInputs) do
+      if v and keybinds.keys[k] and self.args[k] == nil then
+        self.args[k] = false
+      end
     end
   end
 end

--- a/scripts/keybinds.lua
+++ b/scripts/keybinds.lua
@@ -6,141 +6,85 @@ https://github.com/Silverfeelin/Starbound-Keybinds
 keybinds = {
   binds = {},
   initialized = false,
-  version = "1.3.3"
+  version = "1.3.4",
+  debug = true
 }
 
--- For every type of input, set whether it can be bound.
--- EG. Keybind "f up" equals to "up" if "f" is not bindable.
-keybinds.availableInputs = {
-  up = true,
-  left = true,
-  down = true,
-  right = true,
-  primaryFire = true,
-  altFire = true,
-  shift = true,
-  onGround = true,
-  running = true,
-  walking = true,
-  jumping = true,
-  facingDirection = true,
-  liquidPercentage = true,
-  position = true,
-  aimPosition = true,
-  aimRelative = true,
-  f = true,
-  g = true,
-  h = true,
-  specialOne = true,
-  specialTwo = true,
-  specialThree = true,
-  time = true,
-  -- Don't set these to false, ever!
-  aimOffset = true,
-  only = true
-}
+--- Util
 
--- Set used to allow case-insensitive input strings.
-keybinds.inputStrings = {
-  up = "up",
-  left = "left",
-  down = "down",
-  right = "right",
-  primaryfire = "primaryFire",
-  altfire = "altFire",
-  shift = "shift",
-  onground = "onGround",
-  running = "running",
-  walking = "walking",
-  jumping = "jumping",
-  facingdirection = "facingDirection",
-  liquidpercentage = "liquidPercentage",
-  position = "position",
-  aimposition = "aimPosition",
-  aimrelative = "aimRelative",
-  f = "specialOne",
-  g = "specialTwo",
-  h = "specialThree",
-  specialone = "specialOne",
-  specialtwo = "specialTwo",
-  specialthree = "specialThree",
-  time = "time",
-  aimoffset = "aimOffset",
-  only = "only"
-}
+-- {"a"} = {"a" = true}. {"a"} = {f("a") = true}.
+local set = function(values, f) local v = {};  for _,value in pairs(values) do v[f and f(value) or value] = true end return v; end
+-- vec1-vec2
+local sub = function(a, b) return { a[1] - b[1], a[2] - b[2] } end
+-- http://lua-users.org/wiki/SplitJoin
+function string:split(sep) local sep, fields = sep or ":", {}; local pattern = string.format("([^%s]+)", sep); self:gsub(pattern, function(c) fields[#fields+1] = c end); return fields; end
+-- Sets the tostring of of a table to "vec2"
+function keybinds.setVec2(point) setmetatable(point, { __tostring = function() return "vec2" end }) end
 
--- Options that are specifically bound to keys users can hold down.
-keybinds.keys = {
-  up = true,
-  left = true,
-  down = true,
-  right = true,
-  primaryFire = true,
-  altFire = true,
-  shift = true,
-  f = true,
-  g = true,
-  h = true,
-  specialOne = true,
-  specialTwo = true,
-  specialThree = true
-}
+keybinds.inputs = set({
+  "up", "down", "left", "right",
+  "primaryFire", "altFire",
+  "shift", "running", "walking",
+  "onGround", "jumping",
+  "facingDirection", "liquidPercentage",
+  "position", "aimPosition", "aimRelative",
+  "specialOne", "f",
+  "specialTwo", "g",
+  "specialThree", "h",
+  -- Flags
+  "aimOffset", "time", "only", "all"
+}, string.lower)
+
+-- Binds that are specifically bound to keys users can hold down.
+-- Used by flag 'only' and is incompatible with options 'f' 'g' 'h'.
+keybinds.keys = set({
+  "up", "down", "left", "right",
+  "primaryFire", "altFire",
+  "shift",
+  "specialOne",
+  "specialTwo",
+  "specialThree",
+}, string.lower)
 
 -- Default values, do not touch.
 keybinds.input = {
-  up = false, left = false, down = false, right = false,
-  primaryFire = false, altFire = false, shift = false,
-  onGround = true, running = false, walking = false, jumping = false,
-  facingDirection = 1, liquidPercentage = 0,
-  position = {0, 0}, aimPosition = {0, 0}, aimOffset = {2, 2}, aimRelative = {0, 0},
-  f = false, g = false, h = false, specialOne = false, specialTwo = false, specialThree = false,
-  time = 0, only = false
+  onground = true, facingdirection = 1, liquidpercentage = 0,
+  position = {0, 0}, aimposition = {0, 0}, aimoffset = {2, 2}, aimrelative = {0, 0},
+  time = 0
 }
 
--- Unique Bind identifier, used to track time without worrying about shifting indices.
+-- Unique Bind identifier.
 local uid = 1
 
+-- Tracks when time-bound binds can activate.
 local timeActive = {}
 
---[[ Finalizes Keybinds by injecting function keybinds.update in the tech's main update function.]]
-function keybinds.initialize()
-  if not keybinds.initialized then
-    keybinds.initialized = true
-
-    -- Compatibility 'hack' for older versions of the game; use function input rather than update to update the input values (I know, right?!).
-    if input then
-      local originalInput = input
-
-      input = function(args)
-        keybinds.update(args)
-        return originalInput(args)
-      end
-    else
-      local originalUpdate = update
-
-      update = function(args)
-        keybinds.update(args)
-        originalUpdate(args)
-      end
-    end
-
-    sb.logInfo("Keybinds v%s initialized.", keybinds.version)
-  end
+-- Finalizes Keybinds by injecting function keybinds.update in the tech's main update function.
+function keybinds.init()
+  if keybinds.initialized then return end
+  keybinds.initialized = true
+  local og = update
+  update = og and function(args) keybinds.update(args); og(args); end or keybinds.update
+  sb.logInfo("Keybinds v%s initialized.", keybinds.version)
 end
 
+-- Updates Keybinds
 function keybinds.update(args)
   keybinds.updateInput(args)
 
-  for id,bind in pairs(keybinds.binds) do
+  if keybinds.debug then
+    sb.setLogMap("player_rel", string.format("%s %s", keybinds.input.aimrelative[1], keybinds.input.aimrelative[2]))
+  end
 
-    local runFunction = bind:matches(keybinds.input)
+  for id,bind in pairs(keybinds.binds) do
+    local isMatch, matches, noMatches = bind:matches(keybinds.input)
 
     -- Run function if the current input matches the arguments of the bind.
     -- Disables consecutive calls unless the bind is repeatable.
-    if runFunction and (bind.repeatable or not bind.executed) then
-      bind.f()
+    if isMatch and (bind.repeatable or not bind.executed) and (not bind.options.all or bind.argCount == matches) then
+      bind.f(bind)
       bind.executed = true
-    elseif not runFunction and bind.executed then
+    elseif not isMatch and bind.executed and (not bind.options.all or bind.argCount == noMatches) then
       bind.executed = false
     end
   end
@@ -155,29 +99,28 @@ function keybinds.updateInput(args)
   input.down = args.moves.down
   input.right = args.moves.right
 
-  input.primaryFire = args.moves.primaryFire
-  input.altFire = args.moves.altFire
+  input.primaryfire = args.moves.primaryFire
+  input.altfire = args.moves.altFire
 
   input.shift = not args.moves.run
 
-  input.onGround = mcontroller.onGround()
+  input.onground = mcontroller.onGround()
   input.running = mcontroller.running()
   input.walking = mcontroller.walking()
   input.jumping = args.moves.jump
-  input.facingDirection = mcontroller.facingDirection()
-  input.liquidPercentage = mcontroller.liquidPercentage()
+  input.facingdirection = mcontroller.facingDirection()
+  input.liquidpercentage = mcontroller.liquidPercentage()
 
   input.position = mcontroller.position()
-  input.aimPosition = tech.aimPosition()
-  input.aimRelative = {
-    input.aimPosition[1] - input.position[1],
-    input.aimPosition[2] - input.position[2]
-  }
-  sb.setLogMap("player_rel", string.format("%s %s", input.aimRelative[1], input.aimRelative[2]))
+  input.aimposition = tech.aimPosition()
+  input.aimrelative = sub(input.aimposition, input.position)
 
-  input.specialOne = input.f
-  input.specialTwo = input.g
-  input.specialThree = input.h
+  input.specialone = args.moves.special1
+  input.specialtwo = args.moves.special2
+  input.specialthree = args.moves.special3
+  input.f = input.specialone
+  input.g = input.specialtwo
+  input.h = input.specialthree
 end
 
 --[[ Returns a keybind table from the given string.
@@ -188,49 +131,28 @@ function keybinds.stringToKeybind(s)
   for _,v in pairs(s:split(" ")) do
     local separator = v:find("=")
     local key = v:sub(0, separator and separator - 1 or nil):lower()
+    local valueString =  separator and v:sub(separator + 1) or ""
 
-    if not keybinds.availableInputs[keybinds.inputStrings[key]] then
-      sb.logInfo("Keybind argument '%s' ignored.", key)
-    else
-      key = keybinds.inputStrings[key]
-      local valueString =  separator and v:sub(separator + 1) or ""
+    -- Default value is true
+    local value = true
+    if valueString == "false" then
+      value = false
+    elseif valueString == valueString:match("%-?%f[%.%d]%d*%.?%d*%f[^%.%d]") then
+      -- Float
+      value = tonumber(valueString)
+    elseif valueString == valueString:match("%-?%f[%.%d]%d*%.?%d*%f[^%.%d],%-?%f[%.%d]%d*%.?%d*%f[^%.%d]") then
+      -- Vec2
+      local x = tonumber(valueString:sub(0,valueString:find(",") - 1))
+      local y = tonumber(valueString:sub(valueString:find(",") + 1))
+      value = {x,y}
 
-      -- Default value is true
-      local value = true
-
-      if valueString == "false" then
-        value = false
-      elseif valueString == valueString:match("%-?%f[%.%d]%d*%.?%d*%f[^%.%d]") then
-        -- Float
-        value = tonumber(valueString)
-      elseif valueString == valueString:match("%-?%f[%.%d]%d*%.?%d*%f[^%.%d],%-?%f[%.%d]%d*%.?%d*%f[^%.%d]") then
-        -- Vec2
-        local x = tonumber(valueString:sub(0,valueString:find(",") - 1))
-        local y = tonumber(valueString:sub(valueString:find(",") + 1))
-        value = {x,y}
-
-        keybinds.setVec2(value)
-      end
-
-      args[key] = value
+      keybinds.setVec2(value)
     end
+
+    args[key] = value
   end
 
   return args
-end
-
-function keybinds.setVec2(point)
-  setmetatable(point, {
-    __tostring = function() return "vec2" end
-  })
-end
-
--- http://lua-users.org/wiki/SplitJoin
-function string:split(sep)
-  local sep, fields = sep or ":", {}
-  local pattern = string.format("([^%s]+)", sep)
-  self:gsub(pattern, function(c) fields[#fields+1] = c end)
-  return fields
 end
 
 Bind = {}
@@ -238,13 +160,15 @@ Bind.__index = Bind
 
 function Bind.create(args, f, repeatable, disable)
   -- Creating a bind will finalize the set-up, if not done already.
-  keybinds.initialize()
+  keybinds.init()
 
   local bind = {}
+  setmetatable(bind, Bind)
+
   bind.id = uid
   uid = uid + 1
+  bind.options = {}
 
-  setmetatable(bind, Bind)
   bind:change(args, f, repeatable)
 
   bind.active = not disable
@@ -256,72 +180,72 @@ function Bind.create(args, f, repeatable, disable)
 end
 
 function Bind:change(args, f, repeatable)
-  self.args = type(args) == "string" and keybinds.stringToKeybind(args) or args or self.args
-  self.f = f or self.f
+  if type(f) == "function" then self.f = f end
   if type(repeatable) ~= "nil" then self.repeatable = repeatable end
+
+  self.args = type(args) == "string" and keybinds.stringToKeybind(args) or args or self.args
+  if self.args.all then self.options.all = true; self.args.all = nil end
+  if self.args.aimoffset then self.options.aimOffset = self.args.aimoffset; self.args.aimoffset = nil; end
+  if self.args.only then self.options.only = true; self.args.only = nil end
+  if self.args.time then self.options.time = self.args.time; self.args.time = nil end
+
+  self.argCount = 0;
+  for _ in pairs(self.args) do self.argCount = self.argCount + 1 end
+
   self.executed = false
 
-  -- Remove disabled keybinds. Set the tostring of valid tables to vec2.
-  for k,v in pairs(self.args) do
-    if not keybinds.availableInputs[k] then
-      -- Remove disabled keybinds
-      self.args[k] = nil
-    elseif type(v) == "table" and #v == 2 and type(v[1]) == "number" and type(v[2]) == "number" then
-      -- Convert point table tostring to vec2
-      keybinds.setVec2(v)
-    end
+  -- Set the tostring of valid tables to vec2.
+  for _,v in pairs(self.args) do
+    if type(v) == "table" and #v == 2 and type(v[1]) == "number" and type(v[2]) == "number" then keybinds.setVec2(v) end
   end
 
-  -- If "only" is set, set valid unset keys to false.
-  if self.args["only"] then
-    for k,v in pairs(keybinds.availableInputs) do
-      if v and keybinds.keys[k] and self.args[k] == nil then
-        self.args[k] = false
-      end
+  -- If "only" is set, set missing keys to false.
+  if self.options.only then
+    for k in pairs(keybinds.keys) do
+      if self.args[k] == nil then self.args[k] = false end
     end
   end
 end
 
-function Bind:swap(otherBind)
-  self.f, otherBind.f = otherBind.f, self.f
+-- Swaps self.f with target.f
+function Bind:swap(target)
+  self.f, target.f = target.f, self.f
 end
 
-function Bind:toggle()
-  self.active = not self.active
-  if self.active then
-    self:rebind()
-  else
-    self:unbind()
-  end
-end
-
+-- Activates a bind.
 function Bind:rebind()
   self.active = true
   keybinds.binds[self.id] = self
 end
 
+-- Deactivates a bind.
 function Bind:unbind()
   self.active = false
   keybinds.binds[self.id] = nil
 end
 
-function Bind:isActive()
-  return self.active
+-- Toggles the bind. See Bind:rebind and Bind:unbind
+function Bind:toggle()
+  if self.active then self:unbind() else self:rebind() end
 end
-Bind.active = Bind.isActive
 
+-- bind:isActive() = bind.active
+function Bind:isActive() return self.active end
+
+-- Checks if input matches bind.args.
+-- Returns:
+-- * true if bind matches, false otherwise
+-- * amount of matching arguments
+-- * amount of non-matching arguments
 function Bind:matches(input)
-  local runFunction = true
+  local matches, noMatches = 0, 0
 
   -- For every bind, check every arg.
   -- If an arg does not match the current input, prevent the function for this bind from being called.
   for k,v in pairs(self.args) do
-
-    if k == "aimOffset" or k == "time" then
-        goto nextArg
-    end
-
-    if runFunction and v ~= keybinds.input[k] then
+    if keybinds.input[k] == v then
+      matches = matches + 1
+    else
       -- Value for this argument does not match expected value for keybind.
 
       if tostring(v) == "vec2" then
@@ -329,31 +253,34 @@ function Bind:matches(input)
         local dx = math.abs(v[1] - keybinds.input[k][1])
         local dy = math.abs(v[2] - keybinds.input[k][2])
 
-        local offset = bind.args.aimOffset or keybinds.input.aimOffset
+        local offset = self.options.aimOffset or keybinds.input.aimoffset
 
         if dx > offset[1] or dy > offset[2] then
-          runFunction = false
+          noMatches = noMatches + 1
+        else
+          matches = matches + 1
         end
       else
-        runFunction = false
+        noMatches = noMatches + 1
       end
     end
-
-    ::nextArg::
   end
 
   -- Special handling for timed binds.
-  if self.args.time then
+  local timeMatch = true
+  if self.options.time then
     local clock = os.clock()
-    if not runFunction then
+    if (self.options.all and matches ~= self.argCount) or noMatches > 0 then
       timeActive[self.id] = nil
     elseif not timeActive[self.id] then
-      timeActive[self.id] = clock + self.args.time
-      runFunction = false
+      timeActive[self.id] = clock + self.options.time
+      timeMatch = false
     elseif timeActive[self.id] > clock then
-      runFunction = false
+      timeMatch = false
     end
+
   end
 
-  return runFunction
+  local isMatch = timeMatch and noMatches == 0
+  return isMatch, matches, noMatches
 end

--- a/tech/dash/_dash.tech.patch
+++ b/tech/dash/_dash.tech.patch
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "add",
+    "path": "/scripts/-",
+    "value": "keybinds_test.lua"
+  }
+]

--- a/tech/dash/keybinds_scriptHooks.lua
+++ b/tech/dash/keybinds_scriptHooks.lua
@@ -1,0 +1,51 @@
+--- UNLICENSED: FEEL FREE TO USE THIS CODE WITH OR WITHOUT THIS HEADER.
+-- https://gist.github.com/Silverfeelin/3a6286d443d829eed58fa781790e2de5
+-- Usage: hook("init", myTable.myInit)
+
+-- Prevent loading if another scriptHooks has been loaded (i.e. same script in a different folder)
+if hook then return end
+
+local hooks = {}
+
+--- Loops over all functions in hook.
+-- Returns the first non-nil value after calling all hooks.
+local function loop(hook, ...)
+  local ret
+  for k,v in pairs(hook) do
+    if v then
+      local r = k(...)
+      if type(ret) == "nil" then ret = r end
+    end
+  end
+  return ret
+end
+
+--- Creates a new empty hook for the given global function.
+-- The return hook is a key-based table for functions to call.
+local function createHook(name)
+  if hooks[name] then return hooks[name] end
+  local hook = {}
+  hooks[name] = hook
+
+  if _ENV[name] then
+    local old = _ENV[name]
+    _ENV[name] = function(...)
+      old(...)
+      return loop(hook, ...)
+    end
+  else
+    _ENV[name] = function(...)
+      return loop(hook, ...)
+    end
+  end
+
+  return hook
+end
+
+--- Hook a function to the global function.
+-- @param name Global function name.
+-- @param func Function to hook.
+function hook(name, func)
+  local hook = createHook(name)
+  hook[func] = true
+end

--- a/tech/dash/keybinds_test.lua
+++ b/tech/dash/keybinds_test.lua
@@ -1,0 +1,9 @@
+require "/scripts/keybinds.lua"
+require "/tech/dash/keybinds_scriptHooks.lua"
+
+hook("init", function()
+   Bind.create("specialOne", function(bind)
+    world.spawnItem("money", tech.aimPosition())
+    bind:unbind()
+  end)
+end)


### PR DESCRIPTION
* Adds a keyword `only` that can be used to ensure all unset options must be false.
    * `"only up down"` will not fire if `left/right/primaryFire/etc` are true.
* Adds a keyword `all` that can be used to ensure all keys must be released (closes #6).
    * `"all up down"` will not fire a second time until both `up` and `down` are released.
* Bumps version to 1.3.4.
* Moved documentation to Wiki.